### PR TITLE
nyancat.c: Fix string literal printf with no arguments.

### DIFF
--- a/src/nyancat.c
+++ b/src/nyancat.c
@@ -945,7 +945,7 @@ try_again:
 					last = frames[i][y][x];
 					printf("%s%s", colors[frames[i][y][x]], output);
 				} else {
-					printf(output);
+					printf("%s", output);
 				}
 			}
 			if (y != MAX_ROW - 1)


### PR DESCRIPTION
From -Wformat-security in gcc.
