### PR TITLE
Fixed SegFault if TERM variable is not set

### DIFF
--- a/src/nyancat.c
+++ b/src/nyancat.c
@@ -364,7 +364,8 @@ int main(int argc, char ** argv) {
 		/* We are running standalone, retrieve the
 		 * terminal type from the environment. */
 		char * nterm = getenv("TERM");
-		strcpy(term, nterm);
+		if (nterm)
+			strcpy(term, nterm);
 		
 		/* Also get the number of columns */
 		struct winsize w;


### PR DESCRIPTION
If neither TERM variable set nor -t option given nyancat crashes with SIG_SEGV.

It definetely happens 'cause at nyancat.c:353 it tries to strcpy() from null-pointer nterm.
