### PR TITLE
fixes for Solaris

### DIFF
--- a/src/nyancat.c
+++ b/src/nyancat.c
@@ -49,6 +49,7 @@
  * WITH THE SOFTWARE.
  */
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
On Solaris, `TIOCGWINSZ` and `struct winsize` are defined in `<termios.h>`, so use those.

The second patch fixes a warning about `tolower()` being not defined.
