### PR TITLE
Fix useless build flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ OBJECTS = nyancat.o
 all: nyancat
 
 nyancat: $(OBJECTS)
-	$(CC) $(LFLAGS) $(OBJECTS) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@
 
 clean:
 	-rm -f $(OBJECTS) nyancat


### PR DESCRIPTION
Pass CPPFLAGS and CFLAGS to the compiler. I assume LFLAGS was a typo
and should be LDFLAGS instead.

Signed-off-by: Jonathan McCrohan jmccrohan@gmail.com
