### PR TITLE
Fix hyphen-used-as-minus-sign in nyancat.1

### DIFF
--- a/nyancat.1
+++ b/nyancat.1
@@ -2,7 +2,7 @@
 .SH NAME
 nyancat \- terminal-based Pop Tart Cat animation
 .SH SYNOPSIS
-.B nyancat [ -hitn ] [-f frames]
+.B nyancat [ \-hitn ] [\-f frames]
 .SH DESCRIPTION
 .B nyancat
 is an animated, color, ANSI-text program that renders a loop of the
@@ -12,43 +12,43 @@ nyancat makes use of various ANSI escape sequences to render color, or in the ca
 of a VT220, simply dumps text to the screen.
 .SH OPTIONS
 .TP
-.B \-i, --intro
+.B \-i, \-\-intro
 Show introduction / about information on startup.
 .TP
-.B \-t, --telnet
+.B \-t, \-\-telnet
 Enable telnet mode.
 .TP
-.B \-n, --no-counter
+.B \-n, \-\-no\-counter
 Do not display the timer.
 .TP
-.B \-s, --no-title
+.B \-s, \-\-no\-title
 Do not set the titlebar text.
 .TP
-.B \-e, --no-clear
+.B \-e, \-\-no\-clear
 Do not clear the display between frames.
 .TP
-.B \-f, --frames
+.B \-f, \-\-frames
 Display the requested number of frames, then quit.
 .TP
-.B \-r, --min-rows
+.B \-r, \-\-min\-rows
 Crop the animation from the top.
 .TP
-.B \-R, --max-rows
+.B \-R, \-\-max\-rows
 Crop the animation from the bottom.
 .TP
-.B \-c, --min-cols
+.B \-c, \-\-min\-cols
 Crop the animation from the left.
 .TP
-.B \-C, --max-cols
+.B \-C, \-\-max\-cols
 Crop the animation from the right.
 .TP
-.B \-W, --width
+.B \-W, \-\-width
 Crop the animation to the given width.
 .TP
-.B \-H, --height
+.B \-H, \-\-height
 Crop the animation to the given height.
 .TP
-.B \-h, --help
+.B \-h, \-\-help
 Show help message and exit.
 .SH HOMEPAGE
 .PP


### PR DESCRIPTION
Issue reported by Jakub Wilk using Debian Lintian tool.

http://lintian.debian.org/tags/hyphen-used-as-minus-sign.html

Signed-off-by: Jonathan McCrohan jmccrohan@gmail.com
