### PR TITLE
Added definition _DARWIN_C_SOURCE to ensure SIGWINCH is defined on OSX s...

### DIFF
--- a/src/nyancat.c
+++ b/src/nyancat.c
@@ -49,7 +49,6 @@
  * WITH THE SOFTWARE.
  */
 
-
 #define _DARWIN_C_SOURCE 1 /* Required when compiling on OSX, should not affect compilation on other systems */
 #define _XOPEN_SOURCE 500
 #include <ctype.h>


### PR DESCRIPTION
Added definition _DARWIN_C_SOURCE to ensure SIGWINCH is defined on OSX systems when compiling

When not included compilation fails as shown below, adding this switch didn't affect compilation on Ubuntu Server 12.04.4 

``` bash
$ make
cd src && /Applications/Xcode.app/Contents/Developer/usr/bin/make all
cc -g -Wall -Wextra -std=c99 -pedantic -Wwrite-strings   -c -o nyancat.o nyancat.c
nyancat.c:229:9: error: use of undeclared identifier 'SIGWINCH'
        signal(SIGWINCH, SIGWINCH_handler);
               ^`
nyancat.c:614:10: error: use of undeclared identifier 'SIGWINCH'
                signal(SIGWINCH, SIGWINCH_handler);
                       ^
2 errors generated.
make[1]: *** [nyancat.o] Error 1
make: *** [all] Error 2
```
