### PR TITLE
Add _DARWIN_C_SOURCE to allow compiling on OSX

### DIFF
--- a/src/nyancat.c
+++ b/src/nyancat.c
@@ -50,6 +50,7 @@
  */
 
 #define _XOPEN_SOURCE 500
+#define _DARWIN_C_SOURCE 1
 #include <ctype.h>
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
This allows OSX to get declarations for readlink(), setegid(), seteuid() etc when compiling 

Allows successful compile on OSX 10.9.4
Didn't break the build on Linux (tested on Ubuntu Server 12.04 LTS & Centos 6.5
