### PR TITLE
Added __BSD_VISIBLE 1 to allow compiling on FreeBSD.

### DIFF
--- a/src/nyancat.c
+++ b/src/nyancat.c
@@ -51,6 +51,7 @@
 
 #define _XOPEN_SOURCE 500
 #define _DARWIN_C_SOURCE 1
+#define __BSD_VISIBLE 1
 #include <ctype.h>
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
SIGWINCH is defined in signal.h, but on FreeBSD SIGWINCH is guarded by __BSD_VISIBLE as it's not really POSIX.  I've added __BSD_VISIBLE to the main nyan file to let this compile.

I tested compilation on OSX Mavericks and 12.04 ubuntu still functions, and I compiled my code on FreeBSD 10.0.

I have not tested installation under FreeBSD.
