### PR TITLE
Fix a buffer overflow by getting rid of all strcpy() calls

### DIFF
--- a/src/nyancat.c
+++ b/src/nyancat.c
@@ -49,7 +49,7 @@
  * WITH THE SOFTWARE.
  */
 
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #define _DARWIN_C_SOURCE 1
 #define _BSD_SOURCE
 #define __BSD_VISIBLE 1
@@ -347,8 +347,7 @@ void usage(char * argv[]) {
 
 int main(int argc, char ** argv) {
 
-	/* The default terminal is ANSI */
-	char term[1024] = {'a','n','s','i', 0};
+	char *term = NULL;
 	unsigned int k;
 	int ttype;
 	uint32_t option = 0, done = 0, sb_mode = 0;
@@ -485,7 +484,7 @@ int main(int argc, char ** argv) {
 								/* This was a response to the TTYPE command, meaning
 								 * that this should be a terminal type */
 								alarm(2);
-								strcpy(term, (char *)&sb[2]);
+								term = strndup((char *)&sb[2], sizeof(sb)-2);
 								done++;
 							}
 							else if (sb[0] == NAWS) {
@@ -562,10 +561,7 @@ int main(int argc, char ** argv) {
 	} else {
 		/* We are running standalone, retrieve the
 		 * terminal type from the environment. */
-		char * nterm = getenv("TERM");
-		if (nterm) {
-			strcpy(term, nterm);
-		}
+		term = getenv("TERM");
 
 		/* Also get the number of columns */
 		struct winsize w;
@@ -574,36 +570,39 @@ int main(int argc, char ** argv) {
 		terminal_height = w.ws_row;
 	}
 
-	/* Convert the entire terminal string to lower case */
-	for (k = 0; k < strlen(term); ++k) {
-		term[k] = tolower(term[k]);
-	}
+	/* Default ttype */
+	ttype = 2;
 
-	/* Do our terminal detection */
-	if (strstr(term, "xterm")) {
-		ttype = 1; /* 256-color, spaces */
-	} else if (strstr(term, "toaru")) {
-		ttype = 1; /* emulates xterm */
-	} else if (strstr(term, "linux")) {
-		ttype = 3; /* Spaces and blink attribute */
-	} else if (strstr(term, "vtnt")) {
-		ttype = 5; /* Extended ASCII fallback == Windows */
-	} else if (strstr(term, "cygwin")) {
-		ttype = 5; /* Extended ASCII fallback == Windows */
-	} else if (strstr(term, "vt220")) {
-		ttype = 6; /* No color support */
-	} else if (strstr(term, "fallback")) {
-		ttype = 4; /* Unicode fallback */
-	} else if (strstr(term, "rxvt-256color")) {
-		ttype = 1; /* xterm 256-color compatible */
-	} else if (strstr(term, "rxvt")) {
-		ttype = 3; /* Accepts LINUX mode */
-	} else if (strstr(term, "vt100") && terminal_width == 40) {
-		ttype = 7; /* No color support, only 40 columns */
-	} else if (!strncmp(term, "st", 2)) {
-		ttype = 1; /* suckless simple terminal is xterm-256color-compatible */
-	} else {
-		ttype = 2; /* Everything else */
+	if (term) {
+		/* Convert the entire terminal string to lower case */
+		for (k = 0; k < strlen(term); ++k) {
+			term[k] = tolower(term[k]);
+		}
+
+		/* Do our terminal detection */
+		if (strstr(term, "xterm")) {
+			ttype = 1; /* 256-color, spaces */
+		} else if (strstr(term, "toaru")) {
+			ttype = 1; /* emulates xterm */
+		} else if (strstr(term, "linux")) {
+			ttype = 3; /* Spaces and blink attribute */
+		} else if (strstr(term, "vtnt")) {
+			ttype = 5; /* Extended ASCII fallback == Windows */
+		} else if (strstr(term, "cygwin")) {
+			ttype = 5; /* Extended ASCII fallback == Windows */
+		} else if (strstr(term, "vt220")) {
+			ttype = 6; /* No color support */
+		} else if (strstr(term, "fallback")) {
+			ttype = 4; /* Unicode fallback */
+		} else if (strstr(term, "rxvt-256color")) {
+			ttype = 1; /* xterm 256-color compatible */
+		} else if (strstr(term, "rxvt")) {
+			ttype = 3; /* Accepts LINUX mode */
+		} else if (strstr(term, "vt100") && terminal_width == 40) {
+			ttype = 7; /* No color support, only 40 columns */
+		} else if (!strncmp(term, "st", 2)) {
+			ttype = 1; /* suckless simple terminal is xterm-256color-compatible */
+		}
 	}
 
 	int always_escape = 0; /* Used for text mode */


### PR DESCRIPTION
Hello,

When compiling on OpenBSD, the linker produces a warning :

```
cd src && make all
cc -O2 -pipe   -c nyancat.c
cc  -O2 -pipe   nyancat.o -o nyancat
nyancat.o: In function `main':
nyancat.c:(.text+0x7c7): warning: warning: strcpy() is almost always misused, please use strlcpy()
```

After reading the code, it appears there are no boundary checks being done, and setting TERM to a sufficiently long string and running nyancat afterwise triggers a buffer overflow.

```
TERM=0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF
```

OpenBSD linker suggests using strlcpy but it's not part of C99 and is not available on Linux systems, and strncpy should be avoided.

Here is a diff avoiding copying strings altogether and removing the two calls to strcpy().
