### PR TITLE
added _DEFAULT_SOURCE to fix compilation warnings on gcc 5

### DIFF
--- a/src/nyancat.c
+++ b/src/nyancat.c
@@ -52,6 +52,7 @@
 #define _XOPEN_SOURCE 500
 #define _DARWIN_C_SOURCE 1
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define __BSD_VISIBLE 1
 #include <ctype.h>
 #include <stdio.h>


### PR DESCRIPTION
This is fixes compilation warnings with gcc 5.

c -g -Wall -Wextra -std=c99 -pedantic -Wwrite-strings   -c -o nyancat.o nyancat.c
In file included from /usr/include/ctype.h:25:0,
                 from nyancat.c:56:
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^