### PR TITLE
RPM .spec file for RedHat-based distros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-nyancat
+src/nyancat
+*.o
 *.pyc

--- a/nyancat-0.patch
+++ b/nyancat-0.patch
@@ -1,11 +1,25 @@
+diff --git a/sysconfig/nyancat b/sysconfig/nyancat
+new file mode 100644
+index 0000000..31a4bf5
+--- /dev/null
++++ b/sysconfig/nyancat
+@@ -0,0 +1,4 @@
++# nyancat command line args
++# Use /usr/bin/nyancat -h for more info
++NYANCAT_ARGS="-t"
++
+diff --git a/systemd/nyancat@.service b/systemd/nyancat@.service
+index 79c16c1..355587e 100644
 --- a/systemd/nyancat@.service
 +++ b/systemd/nyancat@.service
-@@ -4,7 +4,7 @@ Documentation=man:nyancat(1)
+@@ -3,8 +3,9 @@ Description=nyancat
+ Documentation=man:nyancat(1)
  
  [Service]
++EnvironmentFile=-/etc/sysconfig/nyancat
  User=nobody
 -ExecStart=-/usr/bin/nyancat -t
-+ExecStart=-/usr/bin/nyancat -t -n -I
++ExecStart=-/usr/bin/nyancat $NYANCAT_ARGS
  StandardInput=socket
  StandardOutput=socket
  

--- a/nyancat-0.patch
+++ b/nyancat-0.patch
@@ -1,13 +1,3 @@
-diff --git a/sysconfig/nyancat b/sysconfig/nyancat
-new file mode 100644
-index 0000000..31a4bf5
---- /dev/null
-+++ b/sysconfig/nyancat
-@@ -0,0 +1,4 @@
-+# nyancat command line args
-+# Use /usr/bin/nyancat -h for more info
-+NYANCAT_ARGS="-t"
-+
 diff --git a/systemd/nyancat@.service b/systemd/nyancat@.service
 index 79c16c1..355587e 100644
 --- a/systemd/nyancat@.service

--- a/nyancat-0.patch
+++ b/nyancat-0.patch
@@ -1,0 +1,11 @@
+--- a/systemd/nyancat@.service
++++ b/systemd/nyancat@.service
+@@ -4,7 +4,7 @@ Documentation=man:nyancat(1)
+ 
+ [Service]
+ User=nobody
+-ExecStart=-/usr/bin/nyancat -t
++ExecStart=-/usr/sbin/nyancat -t -n -I
+ StandardInput=socket
+ StandardOutput=socket
+ 

--- a/nyancat-0.patch
+++ b/nyancat-0.patch
@@ -5,7 +5,7 @@
  [Service]
  User=nobody
 -ExecStart=-/usr/bin/nyancat -t
-+ExecStart=-/usr/sbin/nyancat -t -n -I
++ExecStart=-/usr/bin/nyancat -t -n -I
  StandardInput=socket
  StandardOutput=socket
  

--- a/nyancat-1.patch
+++ b/nyancat-1.patch
@@ -1,0 +1,10 @@
+diff --git a/sysconfig/nyancat b/sysconfig/nyancat
+new file mode 100644
+index 0000000..31a4bf5
+--- /dev/null
++++ b/sysconfig/nyancat
+@@ -0,0 +1,4 @@
++# nyancat command line args
++# Use /usr/bin/nyancat -h for more info
++NYANCAT_ARGS="-t"
++

--- a/nyancat.spec
+++ b/nyancat.spec
@@ -28,7 +28,7 @@ of a VT220, simply dumps text to the screen.
 make %{?_smp_mflags}
 
 %install
-install -m 0755 -D -t $RPM_BUILD_ROOT/usr/sbin $RPM_BUILD_DIR/%{name}-%{version}/src/%{name}
+install -m 0755 -D -t $RPM_BUILD_ROOT/usr/bin $RPM_BUILD_DIR/%{name}-%{version}/src/%{name}
 install -m 0644 -D -t $RPM_BUILD_ROOT/lib/systemd/system $RPM_BUILD_DIR/%{name}-%{version}/systemd/%{name}.socket
 install -m 0644 -D -t $RPM_BUILD_ROOT/lib/systemd/system $RPM_BUILD_DIR/%{name}-%{version}/systemd/%{name}@.service
 install -m 0644 -D -t $RPM_BUILD_ROOT/usr/share/man/man1 $RPM_BUILD_DIR/%{name}-%{version}/%{name}.1
@@ -44,7 +44,7 @@ systemctl disable %{name}.socket
 systemctl daemon-reload
 
 %files
-/usr/sbin/%{name}
+/usr/bin/%{name}
 /lib/systemd/system/%{name}.socket
 /lib/systemd/system/%{name}@.service
 /usr/share/man/man1/%{name}.1.gz

--- a/nyancat.spec
+++ b/nyancat.spec
@@ -29,6 +29,7 @@ make %{?_smp_mflags}
 
 %install
 install -m 0755 -D -t $RPM_BUILD_ROOT/usr/bin $RPM_BUILD_DIR/%{name}-%{version}/src/%{name}
+install -m 0644 -D -t $RPM_BUILD_ROOT/etc/sysconfig $RPM_BUILD_DIR/%{name}-%{version}/sysconfig/%{name}
 install -m 0644 -D -t $RPM_BUILD_ROOT/lib/systemd/system $RPM_BUILD_DIR/%{name}-%{version}/systemd/%{name}.socket
 install -m 0644 -D -t $RPM_BUILD_ROOT/lib/systemd/system $RPM_BUILD_DIR/%{name}-%{version}/systemd/%{name}@.service
 install -m 0644 -D -t $RPM_BUILD_ROOT/usr/share/man/man1 $RPM_BUILD_DIR/%{name}-%{version}/%{name}.1
@@ -45,6 +46,7 @@ systemctl daemon-reload
 
 %files
 /usr/bin/%{name}
+/etc/sysconfig/nyancat
 /lib/systemd/system/%{name}.socket
 /lib/systemd/system/%{name}@.service
 /usr/share/man/man1/%{name}.1.gz

--- a/nyancat.spec
+++ b/nyancat.spec
@@ -1,0 +1,53 @@
+Name:		nyancat
+Version:	1.5.1
+Release:	1%{?dist}
+Summary:	Nyancat in your terminal, rendered through ANSI escape sequences.
+
+Group:		Misc
+License:	NCSA
+URL:		https://github.com/froller/nyancat
+Source:		%{name}-%{version}.tar.gz
+Patch0:		%{name}-0.patch
+
+#BuildRequires:	
+Requires:	systemd
+
+%description
+
+nyancat is an animated, color, ANSI-text program that renders a loop of the
+classic Nyan Cat animation. 
+
+nyancat makes use of various ANSI escape sequences to render color, or in the case
+of a VT220, simply dumps text to the screen.
+
+%prep
+%setup -q
+%patch -P 0 -p1
+
+%build
+make %{?_smp_mflags}
+
+%install
+install -m 0755 -D -t $RPM_BUILD_ROOT/usr/sbin $RPM_BUILD_DIR/%{name}-%{version}/src/%{name}
+install -m 0644 -D -t $RPM_BUILD_ROOT/lib/systemd/system $RPM_BUILD_DIR/%{name}-%{version}/systemd/%{name}.socket
+install -m 0644 -D -t $RPM_BUILD_ROOT/lib/systemd/system $RPM_BUILD_DIR/%{name}-%{version}/systemd/%{name}@.service
+install -m 0644 -D -t $RPM_BUILD_ROOT/usr/share/man/man1 $RPM_BUILD_DIR/%{name}-%{version}/%{name}.1
+
+%post
+systemctl daemon-reload
+
+%preun
+systemctl stop %{name}.socket
+systemctl disable %{name}.socket
+
+%postun
+systemctl daemon-reload
+
+%files
+/usr/sbin/%{name}
+/lib/systemd/system/%{name}.socket
+/lib/systemd/system/%{name}@.service
+/usr/share/man/man1/%{name}.1.gz
+%doc
+
+%changelog

--- a/nyancat.spec
+++ b/nyancat.spec
@@ -46,7 +46,7 @@ systemctl daemon-reload
 
 %files
 /usr/bin/%{name}
-/etc/sysconfig/nyancat
+/etc/sysconfig/%{name}
 /lib/systemd/system/%{name}.socket
 /lib/systemd/system/%{name}@.service
 /usr/share/man/man1/%{name}.1.gz


### PR DESCRIPTION
- .spec file for building RPM
- Executable moved to /usr/sbin when packaged to RPM