### PR TITLE
fix missing dependecies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,14 @@ version = 1.5.2
 tarname = $(package)
 distdir = $(tarname)-$(version)
 
-all clean check nyancat:
+all clean check:
 	cd src && $(MAKE) $@
+
+nyancat: src/nyancat.o
+	cd src && $(MAKE) $@
+
+src/nyancat.o: src/nyancat.c src/telnet.h src/animation.c
+	cd src && $(MAKE) nyancat.o
 
 dist: $(distdir).tar.gz
 
@@ -36,4 +42,4 @@ install: all
 	install src/nyancat /usr/bin/${package}
 	gzip -9 -c < nyancat.1 > /usr/share/man/man1/nyancat.1.gz
 
-.PHONY: FORCE all clean check dist distcheck install
+.PHONY: FORCE all clean check dist distcheck install nyancat

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,20 +1,24 @@
+Deps_nyancat = src/nyancat.c
 OBJECTS = nyancat.o
 
 CC	?=
-CFLAGS	 ?= -g -Wall -Wextra -std=c99 -pedantic -Wwrite-strings
+CFLAGS	 ?= -g -Wall -Wextra -std=c99 -pedantic -Wwrite-strings -MMD -MP
 CPPFLAGS ?=
 LDFLAGS  ?=
+DEPFILES = $(OBJECTS:.o=.d)
 
 all: nyancat
 
 nyancat: $(OBJECTS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(OBJECTS) -o $@
 
-clean:
-	-rm -f $(OBJECTS) nyancat
+clean: 
+	-rm -f $(OBJECTS) nyancat $(DEPFILES)
 
 check: all
 	# Unit tests go here. None currently.
 	@echo "*** ALL TESTS PASSED ***"
+
+-include $(DEPFILES)
 
 .PHONY: all clean check


### PR DESCRIPTION
This PR fixes an issue in the Makefile. Specifically, previously, any modifications of files like src/animation.c would not trigger a rebuild of nyancat.o. The PR fixes this by including them as additional dependencies.